### PR TITLE
Update from View.propTypes to ViewPropTypes to match RN v0.44.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "react": ">=15.2.0",
-    "react-native": ">=0.29.0"
+    "react-native": ">=0.44.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React, {PropTypes, PureComponent} from 'react';
-import {Animated, Easing, PanResponder, StyleSheet, View} from 'react-native';
+import {Animated, Easing, PanResponder, StyleSheet, View, ViewPropTypes} from 'react-native';
 
 function noop() {}
 
@@ -79,12 +79,12 @@ export default class Swipeable extends PureComponent {
     swipeStartMinDistance: PropTypes.number,
 
     // styles
-    style: View.propTypes.style,
-    leftContainerStyle: View.propTypes.style,
-    leftButtonContainerStyle: View.propTypes.style,
-    rightContainerStyle: View.propTypes.style,
-    rightButtonContainerStyle: View.propTypes.style,
-    contentContainerStyle: View.propTypes.style
+    style: ViewPropTypes.style,
+    leftContainerStyle: ViewPropTypes.style,
+    leftButtonContainerStyle: ViewPropTypes.style,
+    rightContainerStyle: ViewPropTypes.style,
+    rightButtonContainerStyle: ViewPropTypes.style,
+    contentContainerStyle: ViewPropTypes.style
   };
 
   static defaultProps = {


### PR DESCRIPTION
Update the ViewPropTypes to match the last revision of React Native V0.44.x

> View.propTypes to ViewPropTypes (53905a5) - @bvaughn
https://github.com/facebook/react-native/releases
