### PR TITLE
use prop-types to support react ^16

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "swipe",
     "ListView",
     "TableView"
-  ]
+  ],
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-unresolved, import/extensions */
-import React, {PropTypes, PureComponent} from 'react';
+import React, {PureComponent} from 'react';
 import {Animated, Easing, PanResponder, StyleSheet, View, ViewPropTypes} from 'react-native';
+import {PropTypes} from 'prop-types';
 /* eslint-enable import/no-unresolved, import/extensions */
 
 function noop() {}


### PR DESCRIPTION
`PropTypes` is gone from react v16, causing `react-native-swipeable` to crash inside `require()`. This PR adds the separate `prop-types` dependency.