### PR TITLE
update methode componentWillMount to UNSAFE_componentWillMount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -166,7 +166,7 @@ export default class Swipeable extends PureComponent {
     rightButtonsOpen: false
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const {onPanAnimatedValueRef, onRef} = this.props;
 
     onRef(this);


### PR DESCRIPTION
Fix warning since react update :

```
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.
* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rena
me all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Swipeable
```