### PR TITLE
Render buttons after on layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A powerful React Native swipe component",
   "main": "lib/index.js",
   "scripts": {
+    "prepare": "make build",
     "build": "make build",
     "lint": "make lint"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,7 @@ export default class Swipeable extends PureComponent {
     onRef: PropTypes.func,
     onPanAnimatedValueRef: PropTypes.func,
     swipeStartMinDistance: PropTypes.number,
+    renderButtonsAfterOnLayout: PropTypes.bool,
 
     // styles
     style: ViewPropTypes.style,
@@ -151,7 +152,9 @@ export default class Swipeable extends PureComponent {
     // misc
     onRef: noop,
     onPanAnimatedValueRef: noop,
-    swipeStartMinDistance: 15
+    swipeStartMinDistance: 15,
+    renderButtonsAfterOnLayout: false,
+
   };
 
   state = {
@@ -560,8 +563,13 @@ export default class Swipeable extends PureComponent {
   }
 
   _renderButtons(buttons, isLeftButtons) {
-    const {leftButtonContainerStyle, rightButtonContainerStyle} = this.props;
+    const {leftButtonContainerStyle, rightButtonContainerStyle, renderButtonsAfterOnLayout} = this.props;
     const {pan, width} = this.state;
+
+    if (renderButtonsAfterOnLayout && width === 0) {
+        return null;
+    }
+
     const canSwipeLeft = this._canSwipeLeft();
     const canSwipeRight = this._canSwipeRight();
     const count = buttons.length;


### PR DESCRIPTION
This new prop delays the rendering of the buttons until an OnLayout call has been dispatched, giving us the width of the overlay component.

This was done to fix a scenario where the buttons would show while rendering an heavy overlay item that does not span the entire screen width. 

This caused a glitchy feeling of seeing the button for a sec and then having it disappear.