### PR TITLE
Replace deprecated lifecycle hooks to UNSAFE ones

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -167,14 +167,14 @@ export default class Swipeable extends PureComponent {
     rightButtonsOpen: false
   };
 
-  componentDidMount() {
+  UNSAFE_componentDidMount() {
     const {onPanAnimatedValueRef, onRef} = this.props;
 
     onRef(this);
     onPanAnimatedValueRef(this.state.pan);
   }
 
-  componentWillUnmount() {
+  UNSAFE_componentWillUnmount() {
     this._unmounted = true;
   }
 


### PR DESCRIPTION
I've replaced deprecated lifecycle hooks to their new names.

Closes https://github.com/jshanson7/react-native-swipeable/issues/85